### PR TITLE
#57 Added alias to the james.testing interfaces in the james.testing.…

### DIFF
--- a/test/james.testing.clss.pas
+++ b/test/james.testing.clss.pas
@@ -28,15 +28,14 @@ unit James.Testing.Clss;
 interface
 
 uses
-  James.Testing,
   {$IFDEF FPC}
     fpcunit,
-    James.Testing.FPC
+    James.Testing.FPC,
   {$ELSE}
     TestFramework,
-    James.Testing.Delphi
+    James.Testing.Delphi,
   {$ENDIF}
-  ;
+  James.Testing;
 
 type
   {$IFDEF FPC}
@@ -44,8 +43,6 @@ type
   {$ELSE}
     TTestCase = TestFramework.TTestCase;
   {$ENDIF}
-  ITest = James.Testing.ITest;
-  ITestSuite = James.Testing.ITestSuite;
 
   TTestSuite = class sealed(TInterfacedObject, ITestSuite)
   private

--- a/test/james.testing.clss.pas
+++ b/test/james.testing.clss.pas
@@ -44,6 +44,8 @@ type
   {$ELSE}
     TTestCase = TestFramework.TTestCase;
   {$ENDIF}
+  ITest = James.Testing.ITest;
+  ITestSuite = James.Testing.ITestSuite;
 
   TTestSuite = class sealed(TInterfacedObject, ITestSuite)
   private


### PR DESCRIPTION
…clss unit to prevent name collision in Delphi without needed to use FQINs in the class declaration